### PR TITLE
Adds escape of hyphen on occurrences of regex to fit PCRE2

### DIFF
--- a/src/SimpleHtmlDom.php
+++ b/src/SimpleHtmlDom.php
@@ -442,7 +442,7 @@ class SimpleHtmlDom
             return true;
         }
 
-        if (!preg_match("/^[\w-:]+$/", $tag)) {
+        if (!preg_match("/^[\w\-:]+$/", $tag)) {
             $node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
             if ($this->char==='<') {
                 $this->link_nodes($node, false);

--- a/src/SimpleHtmlDomNode.php
+++ b/src/SimpleHtmlDomNode.php
@@ -580,17 +580,16 @@ class SimpleHtmlDomNode
         // pattern of CSS selectors, modified from mootools
         // Paperg: Add the colon to the attrbute, so that it properly finds <tag attr:ibute="something" > like google does.
         // Note: if you try to look at this attribute, yo MUST use getAttribute since $dom->x:y will fail the php syntax check.
-// Notice the \[ starting the attbute?  and the @? following?  This implies that an attribute can begin with an @ sign that is not captured.
-// This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
-// farther study is required to determine of this should be documented or removed.
-//        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
-        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+        // Notice the \[ starting the attbute?  and the @? following?  This implies that an attribute can begin with an @ sign that is not captured.
+        // This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
+        // farther study is required to determine of this should be documented or removed.
+        // $pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+        $pattern = "/([\w\-:\*]*)(?:\#([\w\-]+)|\.([\w\-]+))?(?:\[@?(!?[\w\-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
         preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
         if (is_object($debugObject)) {$debugObject->debugLog(2, "Matches Array: ", $matches);}
 
         $selectors = array();
         $result = array();
-        //print_r($matches);
 
         foreach ($matches as $m) {
             $m[0] = trim($m[0]);


### PR DESCRIPTION
As PHP gets updated to versions above 7.3 PCRE engine migrates to PCRE2 making it necessary to change regular expressions. In this case we escape the hyphen to avoid compilation errors like _"preg_match(): Compilation failed: invalid range in character class at offset ...".